### PR TITLE
Supports export Esbuild metafile

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": [
     "deepmerge",
+    "metafile",
     "middlewares"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ rne bundle --platform=<platform> --bundle-output=<dest>
 | `--assets-dest` | assets directory | |
 | `--dev` | set as development environment | `true` |
 | `--minify` | enable minify | `false` |
+| `--metafile` | Export [Esbuild metafile](https://esbuild.github.io/api/#metafile) | `false` |
 | `--verbose` | print all logs | `false` |
 | `--timestamp` | print timestamp in log | `false` |
 | `--reset-cache` | reset transform cache | `false` |

--- a/packages/cli/lib/command.ts
+++ b/packages/cli/lib/command.ts
@@ -87,6 +87,11 @@ export function cli(): Argv | Promise<Argv> {
             describe: 'enable minify',
             type: 'boolean',
           },
+          metafile: {
+            describe: 'make metafile.json file for esbuild analyze',
+            type: 'boolean',
+            default: false,
+          },
           ...commonOptions,
         })
         .demandOption(['output', 'platform'])

--- a/packages/cli/lib/helpers/index.ts
+++ b/packages/cli/lib/helpers/index.ts
@@ -27,6 +27,7 @@ export function getOptions(argv: Argv): StartOptions | BuildOptions {
   const platform = argv.platform as BundleConfig['platform'];
   const dev = Boolean(argv.dev ?? process.env.NODE_ENV === 'development');
   const minify = Boolean(argv.minify ?? !dev);
+  const metafile = Boolean(argv.metafile ?? false);
   const verbose = typeof argv.verbose === 'boolean' ? argv.verbose : undefined;
   const timestamp = argv.timestamp;
   const resetCache =
@@ -46,6 +47,7 @@ export function getOptions(argv: Argv): StartOptions | BuildOptions {
     platform,
     dev,
     minify,
+    metafile,
   };
 
   return typeof argv.port === 'number'

--- a/packages/config/lib/transformers/esbuild.ts
+++ b/packages/config/lib/transformers/esbuild.ts
@@ -18,6 +18,7 @@ export function getEsbuildOptions(
     outfile = DEFAULT_OUTFILE,
     platform,
     minify,
+    metafile,
   } = bundleConfig;
 
   const platforms = [platform, 'native', 'react-native'];
@@ -52,6 +53,7 @@ export function getEsbuildOptions(
     bundle: true,
     sourcemap: true,
     minify,
+    metafile,
     logLevel: 'silent',
   };
 

--- a/packages/config/lib/types.ts
+++ b/packages/config/lib/types.ts
@@ -19,6 +19,7 @@ export interface BundleConfig {
   assetsDir?: string;
   dev?: boolean;
   minify?: boolean;
+  metafile?: boolean;
   platform: BundlerSupportPlatform;
 }
 

--- a/packages/core/lib/bundler/bundler.ts
+++ b/packages/core/lib/bundler/bundler.ts
@@ -23,7 +23,7 @@ import type {
   PromiseHandler,
 } from '../types';
 import { BundlerEventEmitter } from './events';
-import { createBuildStatusPlugin } from './plugins';
+import { createBuildStatusPlugin, createMetafilePlugin } from './plugins';
 import {
   getGlobalVariables,
   getReactNativeInitializeCore,
@@ -94,6 +94,7 @@ export class ReactNativeEsbuildBundler extends BundlerEventEmitter {
           this.handleBuildEnd(result, context);
         },
       }),
+      createMetafilePlugin(),
       ...this.plugins,
     ];
 
@@ -129,7 +130,7 @@ export class ReactNativeEsbuildBundler extends BundlerEventEmitter {
   }
 
   private handleBuildStart(context: PluginContext): void {
-    this.resetTask(context.id);
+    this.resetTask(context);
     this.emit('build-start', { id: context.id });
   }
 
@@ -223,7 +224,11 @@ export class ReactNativeEsbuildBundler extends BundlerEventEmitter {
     return this.buildTasks.get(targetTaskId)!;
   }
 
-  private resetTask(buildTaskId: number): void {
+  private resetTask(context: PluginContext): void {
+    // task does not exist in bundle mode
+    if (context.mode === 'bundle') return;
+
+    const buildTaskId = context.id;
     const targetTask = this.buildTasks.get(buildTaskId);
     this.assertBuildTask(targetTask);
     logger.debug(`reset task (id: ${buildTaskId})`, {

--- a/packages/core/lib/bundler/plugins/index.ts
+++ b/packages/core/lib/bundler/plugins/index.ts
@@ -1,1 +1,2 @@
+export { createMetafilePlugin } from './metafilePlugin';
 export { createBuildStatusPlugin } from './statusPlugin';

--- a/packages/core/lib/bundler/plugins/metafilePlugin.ts
+++ b/packages/core/lib/bundler/plugins/metafilePlugin.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { BuildResult } from 'esbuild';
+import { logger } from '../../shared';
+import type { EsbuildPluginFactory } from '../../types';
+
+const NAME = 'metafile-plugin';
+
+export const createMetafilePlugin: EsbuildPluginFactory = () => {
+  return function metafilePlugin(context) {
+    return {
+      name: NAME,
+      setup: (build): void => {
+        build.onEnd(async (result: BuildResult) => {
+          const { metafile } = result;
+          const filename = path.join(
+            context.root,
+            `metafile-${context.platform}-${new Date()
+              .getTime()
+              .toString()}.json`,
+          );
+
+          if (metafile) {
+            logger.debug('writing esbuild metafile', { destination: filename });
+            await fs.writeFile(filename, JSON.stringify(metafile), {
+              encoding: 'utf-8',
+            });
+          }
+        });
+      },
+    };
+  };
+};


### PR DESCRIPTION
# Description

Now can export Esbuild metafile with `--metafile` option on bundle command

## Preview

<img width="1468" alt="image" src="https://github.com/leegeunhyeok/react-native-esbuild/assets/26512984/393ce859-ad5a-4b8f-8af3-713bb7665d3b">

close #8