### PR TITLE
Support grouped console log

### DIFF
--- a/packages/core/lib/bundler/bundler.ts
+++ b/packages/core/lib/bundler/bundler.ts
@@ -76,6 +76,15 @@ export class ReactNativeEsbuildBundler extends BundlerEventEmitter {
     // default reporter (for logging)
     switch (event.type) {
       case 'client_log': {
+        if (event.level === 'group' || event.level === 'groupCollapsed') {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument -- allow any
+          this.appLogger.group(...(event.data as any[]));
+          return;
+        } else if (event.level === 'groupEnd') {
+          this.appLogger.groupEnd();
+          return;
+        }
+
         this.appLogger[event.level as keyof Logger](
           // @ts-expect-error this.appLogger[event.logger] is logger function
           // eslint-disable-next-line @typescript-eslint/no-explicit-any -- allow any

--- a/packages/dev-server/lib/middlewares/hotReload.ts
+++ b/packages/dev-server/lib/middlewares/hotReload.ts
@@ -7,7 +7,6 @@ import type {
   HmrUpdateDoneMessage,
   HmrUpdateMessage,
   HmrUpdateStartMessage,
-  LogMessage,
 } from '../types';
 
 const getMessage = (data: Data): HmrClientMessage | null => {
@@ -17,21 +16,6 @@ const getMessage = (data: Data): HmrClientMessage | null => {
     return 'type' in parsedData ? (parsedData as HmrClientMessage) : null;
   } catch (error) {
     return null;
-  }
-};
-
-export const convertHmrLogLevel = (
-  level: LogMessage['level'],
-): ClientLogEvent['level'] => {
-  switch (level) {
-    // TODO: need to support
-    case 'group':
-    case 'groupCollapsed':
-    case 'groupEnd':
-      return 'log';
-
-    default:
-      return level;
   }
 };
 
@@ -59,7 +43,7 @@ export const createHotReloadMiddleware = ({
       case 'log': {
         onLog?.({
           type: 'client_log',
-          level: convertHmrLogLevel(message.level),
+          level: message.level,
           data: message.data,
           mode: 'BRIDGE',
         });


### PR DESCRIPTION
# Description

Support grouped console log

## Preview

```js
console.group('group 1');
console.log('1');
console.log('2');
console.log('3');
console.group('group 2');
console.log('a');
console.log('b');
console.log('c');
console.groupEnd();
console.groupEnd();
```

(Before)
<img width="328" alt="Screenshot 2023-09-27 at 8 29 15 PM" src="https://github.com/leegeunhyeok/react-native-esbuild/assets/26512984/42a47cc3-02db-4532-a67a-a76957ff76cf">

(After)
<img width="308" alt="Screenshot 2023-09-27 at 9 20 44 PM" src="https://github.com/leegeunhyeok/react-native-esbuild/assets/26512984/c5499b57-277d-476e-9101-7ef45699c88a">

