### PR TITLE
fix(docs): resolve `basic-configuration` path

### DIFF
--- a/docs/pages/getting-started/installation.md
+++ b/docs/pages/getting-started/installation.md
@@ -31,7 +31,7 @@ And create `react-native-esbuild.js` to project root.
 exports.default = {};
 ```
 
-for more details, go to [Configuration](/configuration/basic).
+for more details, go to [Configuration](/configuration/basic-configuration).
 
 ## Native Setup
 


### PR DESCRIPTION
### Description
- Resolved `basic-conficuration` path in the `Installation` docs 

https://github.com/leegeunhyeok/react-native-esbuild/assets/29726020/1e91b625-d786-494c-a7df-758fc10c739b


Just a little change, hope this helps. Thank you!
